### PR TITLE
Disable vehnicle interactions with acid puddles.

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -55,13 +55,6 @@ if data.raw["recipe"]["rifle"] then
 	table.insert(data.raw["recipe"]["flying-fortress"]["expensive"].ingredients, {"rifle", 30})
 end
 end
-if settings.startup["disable-acid-splash"].value == true then
-	for k, fire in pairs (data.raw.fire) do
-		if fire.name:find("acid%-splash%-fire") then
-		fire.on_damage_tick_effect = nil
-		end
-	end
-end
 --Hardmode changes
 if settings.startup["aircraft-hardmode"].value == true then
 	--Cargo Plane

--- a/locale/de/all.cfg
+++ b/locale/de/all.cfg
@@ -74,7 +74,6 @@ raven-tech=Schlüsseltechnologie für Raven
 heli-equipment-grid=Helikopter Ausrüstungs-Grid
 non-combat-mode=Friedlicher Modus
 inserter-immunity=Greifarm-Immunität
-disable-acid-splash=Säure-Pfützen deaktivieren
 
 [mod-setting-description]
 aircraft-sound-setting=Deaktivieren, um in allen Flugzeugen Fahrzeug- statt Flugzeug-Geräusche zu verwenden.
@@ -85,4 +84,3 @@ raven-tech=Ordnet die Raven Technologie unterhalb der Erweiterte-Aerodynamik Tec
 heli-equipment-grid=Gibt Helikoptern (sofern installiert) das gleiche Ausrüstungs-Grid wie einem Aufklärungs-Flugzeug.
 non-combat-mode=Deaktiviert Jets, Aufklärungs-Flugzeuge und Fliegende Festungen im Technologiebaum
 inserter-immunity=Macht alle Flugzeuge immun gegen Greifarme, ausgenommen ist das Nachfüllen von Treibstoff.
-disable-acid-splash=Deaktiviert den Schaden, den Säure-Pfützen von Spittern und Würmern machen. DIES IST EINE GLOBALE ÄNDERUNG.

--- a/locale/en/all.cfg
+++ b/locale/en/all.cfg
@@ -74,7 +74,6 @@ raven-tech=Raven Technology Gate
 heli-equipment-grid=Helicopter Equipment Patch
 non-combat-mode=Non-combat mode
 inserter-immunity=Inserter Immunity
-disable-acid-splash=Disable Acid Splash
 
 [mod-setting-description]
 aircraft-sound-setting=Uncheck if you want to use the car sounds instead of the jet sounds in all aircraft.
@@ -85,4 +84,3 @@ raven-tech=Gates the Raven technology behind the Advanced Aerodynamics technolog
 heli-equipment-grid=Gives Helicopters the right to use aircraft-specific equipment. Use only if you have HelicoptersRevival installed.
 non-combat-mode=Disables the Jet, Gunship, and Flying Fortress from the tech tree. (Currently irreversible per-save!)
 inserter-immunity=Makes all aircraft immune to inserters, except for fuel insertion.
-disable-acid-splash=Disables the damage from the acid puddles that spitters and worms makes. (GLOBALLY disables acid puddle damage!)

--- a/locale/fr/all.cfg
+++ b/locale/fr/all.cfg
@@ -73,7 +73,6 @@ raven-tech=Technologie de Raven - Portail
 heli-equipment-grid=Grille d'équipement d'hélicoptère
 non-combat-mode=Mode sans combat
 inserter-immunity=Immunité des bras robotisés
-disable-acid-splash=Désactiver les projections d'acide
 
 [mod-setting-description]
 aircraft-sound-setting=Décochez cette case si vous voulez utiliser les sons de la voiture au lieu des sons des jets dans tous les avions.
@@ -84,4 +83,3 @@ raven-tech=Gates the Raven technology derrière la technologie aérodynamique av
 heli-equipment-grid=Donne à Helicopters (si installé) la même grille d'équipement qu'un avion de combat.
 non-combat-mode=Désactive le jet, l'avion de combat et la forteresse volante de l'arbre technologique.
 inserter-immunity=Immunise tous les aéronefs contre les dispositifs d'insertion, à l'exception des dispositifs d'insertion de carburant.
-disable-acid-splash=Désactive les dommages causés par les flaques d'acide des cracheurs et des vers. C'EST UN CHANGEMENT GLOBAL.

--- a/locale/ja/all.cfg
+++ b/locale/ja/all.cfg
@@ -74,7 +74,6 @@ raven-tech=レイヴンのテクノロジーゲート
 heli-equipment-grid=ヘリコプターの装備グリッド
 non-combat-mode=非戦闘モード
 inserter-immunity=インサータ耐性
-disable-acid-splash=アシッドスプラッシュ無効
 
 [mod-setting-description]
 aircraft-sound-setting=全ての航空機にジェット機のサウンドを使用する代わりに自動車のサウンドを使用したい場合はチェックを外します。
@@ -85,4 +84,3 @@ raven-tech=レイヴンのテクノロジーを高度な航空力学テクノロ
 heli-equipment-grid=(インストールされている場合)ヘリコプターにガンシップと同じ装備グリッドを提供します。
 non-combat-mode=テクノロジーツリーのジェット機、ガンシップ、飛行要塞を無効にします。
 inserter-immunity=燃料の挿入を除いて、全ての航空機がインサータの影響を受けないようにします。
-disable-acid-splash=スピッターやワームが作る酸溜まりからのダメージを無効にします。これはグローバルな変更です。

--- a/locale/pl/all.cfg
+++ b/locale/pl/all.cfg
@@ -73,7 +73,6 @@ raven-tech=Samoloty klasy Raven
 heli-equipment-grid=Wyposażenie śmigłowców
 non-combat-mode=Tryb pokojowy
 inserter-immunity=Wyłącz podajniki dla samolotów
-disable-acid-splash=Wyłącz plamy kwasu
 
 [mod-setting-description]
 aircraft-sound-setting=Odznacz jeżeli chcesz używać dźwieku samochodu w samolotach.
@@ -84,4 +83,3 @@ raven-tech=Dodaje badania nad samolotami klasy Raven. Używać tylko z modyfikac
 heli-equipment-grid=Helikoptery będą miały to samo wyposażenie co samoloty myśliwskie.
 non-combat-mode=Usuwa myśliwce, odrzutowce i latające fortece z gry.
 inserter-immunity=Podajniki nie mogą włożyć do samolotu nic poza paliwem.
-disable-acid-splash=Wyłącza obrażenia od plam kwasu pozostawianych przez kąsacze i czerwie. TO JEST ZMIANA GLOBALNA!

--- a/locale/pt-br/all.cfg
+++ b/locale/pt-br/all.cfg
@@ -73,7 +73,6 @@ raven-tech=Portão de Tecnologia Raven
 heli-equipment-grid=Grelha de Equipamentos para Helicópteros
 non-combat-mode=Modo não-combate
 inserter-immunity=Imunidade ao Inserção
-disable-acid-splash=Desativar respingo de ácido
 
 [mod-setting-description]
 aircraft-sound-setting=Desmarque se você quiser usar os sons do carro em vez dos sons do jato em todas as aeronaves.
@@ -84,4 +83,3 @@ raven-tech=Gates a tecnologia Raven por trás da tecnologia Aerodnâmica avança
 heli-equipment-grid=Dá aos helicópteros (se instalados) a mesma grade de equipamento que um Gunship.
 non-combat-mode=Desativa o Jet, o Gunship e o Flying Fortress da árvore tecnológica.
 inserter-immunity=Torna todas as aeronaves imunes a insersores, exceto para inserção de combustível.
-disable-acid-splash=Desativa o dano das poças ácidas que cuspidores e vermes fazem. ESTA É UMA MUDANÇA GLOBAL.

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -111,6 +111,8 @@ local carsounds = {
 local function add_recurrent_params(craft)
   craft.icon_size = 64
   craft.flags = {"placeable-neutral", "player-creation", "placeable-off-grid"}
+  -- Overriding the "car" default disables acid puddle damage.
+  craft.trigger_target_mask = { "common" }
   craft.has_belt_immunity = settings.startup["aircraft-belt-immunity"].value or false
   craft.dying_explosion = "medium-explosion"
   craft.terrain_friction_modifier = 0

--- a/settings.lua
+++ b/settings.lua
@@ -63,11 +63,4 @@ data:extend(
     default_value = false,
     order = "be",
   },
-  {
-    type = "bool-setting",
-    name = "disable-acid-splash",
-    setting_type = "startup",
-    default_value = false,
-    order = "bf",
-  }
 })


### PR DESCRIPTION
Prevent aircraft from getting the acid debuff/DOT when moving over an acid puddle.

Background:

The default for `car` is `{ "common", "ground-unit" }`, and the acid's "fire" puddles are the only thing that I could find that specifies `"ground-unit"` but not `"common"`.

I tested this and it prevents the acid stickers from attaching when flying over a puddle.  Spitters will still attack and direct damage from the projectile still works.  The acid stickers from projectiles themselves are applied.  

This does not disable melee attack damage.

The two forum links [in the docs](https://lua-api.factorio.com/latest/types/TriggerTargetMask.html) contain some useful explanation.

Let me know if you want a removal for the global acid puddle disable option as well.